### PR TITLE
use `sudo bash` instead of `sudo -s`

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -35,7 +35,7 @@ chmod +x generate-props.sh
 . generate-props.sh
 
 echo "Asking for root access"
-sudo -s <<EOF
+sudo bash <<EOF
 mount -o remount,rw /
 
 mkdir /home/anbox


### PR DESCRIPTION
Install script didn't work for me because I'm using `fish` as my shell, this fixed the issue.